### PR TITLE
fix: APPLICATION_MODAL type doesn't exist upon the discord-interactions

### DIFF
--- a/examples/modal.js
+++ b/examples/modal.js
@@ -22,7 +22,7 @@ app.post('/interactions', function (req, res) {
     if (data.name === 'test') {
       // Send a modal as response
       return res.send({
-        type: InteractionResponseType.APPLICATION_MODAL,
+        type: InteractionResponseType.MODAL,
         data: {
           custom_id: 'my_modal',
           title: 'Modal title',

--- a/examples/modal.js
+++ b/examples/modal.js
@@ -61,7 +61,7 @@ app.post('/interactions', function (req, res) {
   /**
    * Handle modal submissions
    */
-  if (type === InteractionType.APPLICATION_MODAL_SUBMIT) {
+  if (type === InteractionType.MODAL_SUBMIT) {
     // custom_id of modal
     const modalId = data.custom_id;
     // user ID of member who filled out modal


### PR DESCRIPTION
As of https://github.com/discord/discord-interactions-js/blob/main/src/index.ts the type should be MODAL, not APPLICATION_MODAL. Discovered from https://github.com/discord/discord-example-app/issues/21