### PR TITLE
Fix typo in the example code of Getting Started

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -105,7 +105,6 @@ app.post('/interactions', async function (req, res) {
         await res.send({
           type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
           data: {
-            // Fetches a random emoji to send from a helper function
             content: 'What is your object of choice?',
             // Indicates it'll be an ephemeral message
             flags: InteractionResponseFlags.EPHEMERAL,


### PR DESCRIPTION
- Issues
    - No issue has been created
- Changes proposed in this pull request
    - Deleted a line of comment that didn't match the content of the code.
    - I think it's left over after being copied and pasted from the test command. 
        - https://github.com/discord/discord-example-app/blob/main/app.js#L50

I've also created a corresponding pull request to discord-api-docs repository. (https://github.com/discord/discord-api-docs/pull/6353)
