### PR TITLE
Use hard-coded image so it works in glitch's UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project contains a basic rock-paper-scissors-style Discord app written in JavaScript, built for the [getting started guide](https://discord.com/developers/docs/getting-started).
 
-![Demo of app](/assets/getting-started-demo.gif?raw=true)
+![Demo of app](https://github.com/discord/discord-example-app/raw/main/assets/getting-started-demo.gif?raw=true)
 
 > ✨ A version of this code is also hosted **[on Glitch 🎏](https://glitch.com/~getting-started-discord)** and **[on Replit 🌀](https://replit.com/github/discord/discord-example-app)**
 


### PR DESCRIPTION
This updates a gif url so that the glitch example doesn't show a broken image. The github image continues to work as expected.

Example of broken image:
<img width="669" alt="Screen Shot 2023-08-28 at 11 46 39 AM" src="https://github.com/discord/discord-example-app/assets/4811753/d4433c38-a1ad-48c1-a4a0-d44866b28a18">
