### PR TITLE
Fix for MESSAGE_COMPONENT interaction falling through to error section

### DIFF
--- a/examples/app.js
+++ b/examples/app.js
@@ -176,6 +176,8 @@ app.post('/interactions', verifyKeyMiddleware(process.env.PUBLIC_KEY), async fun
         }
       }
     }
+    
+    return;
   }
 
   console.error('unknown interaction type', type);


### PR DESCRIPTION
The example in app.js automatically falls through to the error handler.  Adding a return statement at the bottom of the MESSAGE_COMPONENT handler section fixes the issue.